### PR TITLE
Url fix

### DIFF
--- a/src/sparky/connection/conn.py
+++ b/src/sparky/connection/conn.py
@@ -32,6 +32,9 @@ def setup_connection() -> Tuple[requests.Session, str]:
     url = str(sel_resp[3]).strip().replace("http://", "https://")
     if url.find("https://") == -1:
         url = "https://" + url
+    # Remove trailing slashes before appending the rest of the URL (common if copied from a browser)
+    if url[-1] == '/':
+        url = url[:-1]
     if not url.endswith("service-now.com"):
         url += ".service-now.com"
 
@@ -54,15 +57,3 @@ def setup_connection() -> Tuple[requests.Session, str]:
         sys.exit()
 
 
-if __name__ == '__main__':
-    url = str('https://brinkscustomerdev.service-now.com/').strip().replace("http://", "https://")
-    if url.find("https://") == -1:
-        url = "https://" + url
-    # Remove trailing slashes before appending the rest of the URL (common if copied from a browser)
-    if url[-1] == '/':
-        url = url[:-1]
-    if not url.endswith("service-now.com"):
-        url += ".service-now.com"
- 
-
-    print(url)

--- a/src/sparky/connection/conn.py
+++ b/src/sparky/connection/conn.py
@@ -52,3 +52,17 @@ def setup_connection() -> Tuple[requests.Session, str]:
     else:
         click.secho("Abnormal status code for instance (" + str(resp.status_code) + "), aborting.", fg="red")
         sys.exit()
+
+
+if __name__ == '__main__':
+    url = str('https://brinkscustomerdev.service-now.com/').strip().replace("http://", "https://")
+    if url.find("https://") == -1:
+        url = "https://" + url
+    # Remove trailing slashes before appending the rest of the URL (common if copied from a browser)
+    if url[-1] == '/':
+        url = url[:-1]
+    if not url.endswith("service-now.com"):
+        url += ".service-now.com"
+ 
+
+    print(url)


### PR DESCRIPTION
Added code to `conn.py` to remove trailing slashes ('/') before appending the rest of the URL.  Otherwise urls like https://brinkscustomerdev.service-now.com/ will break and turn into https://brinkscustomerdev.service-now.com/.service-now.com

